### PR TITLE
Add a gauge to measure build waiting time.

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -377,10 +377,11 @@ public class DatadogUtilities {
    * @return a JSONArray containing a specific subset of tags retrieved from a builds metadata.
    */
   public static JSONArray assembleTags(final JSONObject builddata, final HashMap<String,String> extra) {
+    DatadogBuildListener.DescriptorImpl descriptor = DatadogUtilities.getDatadogDescriptor();
     JSONArray tags = new JSONArray();
 
     tags.add("job:" + builddata.get("job"));
-    if ( (builddata.get("node") != null) && DatadogUtilities.getDatadogDescriptor().getTagNode() ) {
+    if ( (builddata.get("node") != null) && descriptor.getTagNode() != null && descriptor.getTagNode() ) {
       tags.add("node:" + builddata.get("node"));
     }
 


### PR DESCRIPTION
With a dynamically sized pool of agents it's important to know if you're scaling
appropriately and where you need to add more capacity.  This PR adds a metric for
each build to let you know how long it had to wait in the queue before executing.